### PR TITLE
Fixed xcframework not generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,45 @@ The Surfile has to be inside your ./SM directory.
 
 The Surfile stores the automation configuration that can be run with _surmagic_.
 
+The Surfile supports new and legacy configuration. One supports multiple XCFrameworks, while the other supports only single XCFramework. The two kinds of configurations can be mixed.
+
+### New Configuration (Support multiple XCFrameworks)
+```xml
+<dict>
+  <key>output_path</key>
+  <string>_OUTPUT_DIRECTORY_NAME_HERE_</string>
+  <key>frameworks</key>
+  <array>
+      <dict>
+          <key>name</key>
+          <string>_FRAMEWORK_NAME_HERE_</string>
+          <key>targets</key>
+          <array>
+              <dict>
+                  <key>sdk</key>
+                  <string>_TARGET_OS_HERE_</string>
+                  <key>workspace</key>
+                  <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
+                  <key>scheme</key>
+                  <string>_SCHEME_NAME_HERE_</string>
+              </dict>
+              <!--
+              Remove this comment and add more targets for Simulators and the Devices.
+              -->
+          </array>
+      </dict>
+      <!--
+      Remove this comment and add more frameworks.
+      -->
+  </array>
+  <key>finalActions</key>
+  <array>
+    <string>openDirectory</string>
+  </array>
+</dict>
+```
+
+### Legacy Configuration (Support only single XCFramework)
 ```xml
 <dict>
   <key>output_path</key>

--- a/surmagic/Package.resolved
+++ b/surmagic/Package.resolved
@@ -6,8 +6,17 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "47bd06ebeff8146ecd0020809e186218b46f465f",
-          "version": "0.4.2"
+          "revision": "fddd1c00396eed152c45a46bea9f47b98e59301d",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
         }
       },
       {
@@ -15,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core",
         "state": {
           "branch": null,
-          "revision": "ab6339b6a33b69886b3cf2254d3326eddfe58eb0",
-          "version": "0.2.2"
+          "revision": "284a41800b7c5565512ec6ae21ee818aac1f84ac",
+          "version": "0.4.0"
         }
       }
     ]

--- a/surmagic/Package.swift
+++ b/surmagic/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.4.0"),
-        .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.2.2"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.4.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/surmagic/Package.swift
+++ b/surmagic/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(name: "surmagic",
+        .executableTarget(name: "surmagic",
                 dependencies: [
                     .product(name: "ArgumentParser", package: "swift-argument-parser"),
                     .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),

--- a/surmagic/Sources/surmagic/Framework.swift
+++ b/surmagic/Sources/surmagic/Framework.swift
@@ -1,0 +1,47 @@
+//
+//  Framework.swift
+//  Surmagic
+//
+//  Created by FFirX on 2022/12/28.
+//  Copyright © 2022 FFirX
+//
+
+import Foundation
+
+/// Content of the Surfile.
+public class Framework: Codable {
+    
+    // MARK: - Properties
+
+    /// Name of the target framework.
+    let name: String
+    
+    /// The array of the target frameworks to create.
+    let targets: [Target]?
+
+    public init(name: String, targets: [Target]?) {
+        self.name = name
+        self.targets = targets
+    }
+    
+    public var desc: String {
+        var result = (
+            " name: \(String(name)) \n"
+        )
+        
+        if let targets = targets {
+            for item in targets {
+                result.append(contentsOf: " target: " + item.desc + " \n")
+            }
+        }
+        
+        return result
+    }
+    
+    // MARK: - Types
+    
+    enum CodingKeys: String, CodingKey {
+        case name = "name"
+        case targets = "targets"
+    }
+}

--- a/surmagic/Sources/surmagic/Surfile.swift
+++ b/surmagic/Sources/surmagic/Surfile.swift
@@ -92,24 +92,36 @@ public class Surfile: Codable {
     let output_path: String
     
     /// Name of the target framework.
-    let framework: String
-    
+    let framework: String?
+
     /// The array of the target frameworks to create.
     let targets: [Target]?
     
+    /// The array of the frameworks to create.
+    let frameworks: [Framework]?
+
     /// Final actions after finishing the work. If it's empty, no action will take by the system.
     ///  - @usage: ["openDirectory", ...etc]
     let finalActions: [FinalAction]?
     
     public var desc: String {
         var result = (
-            " output_path: \(String(output_path)) \n" +
-            " framework: \(String(framework)) \n"
+            " output_path: \(String(output_path)) \n"
         )
+
+        if let framework = framework {
+            result.append(contentsOf: " framework: " + framework + " \n")
+        }
         
         if let targets = targets {
             for item in targets {
                 result.append(contentsOf: " target: " + item.desc + " \n")
+            }
+        }
+
+        if let frameworks = frameworks {
+            for item in frameworks {
+                result.append(contentsOf: " framework: " + item.desc + " \n")
             }
         }
         
@@ -128,6 +140,7 @@ public class Surfile: Codable {
         case output_path = "output_path"
         case framework = "framework"
         case targets = "targets"
+        case frameworks = "frameworks"
         case finalActions = "finalActions"
     }
 }

--- a/surmagic/Sources/surmagic/Surfile.swift
+++ b/surmagic/Sources/surmagic/Surfile.swift
@@ -15,18 +15,23 @@ import Foundation
  <dict>
      <key>output_path</key>
      <string>_OUTPUT_DIRECTORY_NAME_HERE_</string>
-     <key>framework</key>
-     <string>_FRAMEWORK_NAME_HERE_</string>
-     <key>targets</key>
+     <key>frameworks</key>
      <array>
-         <dict>
-             <key>sdk</key>
-             <string>_TARGET_OS_HERE_</string>
-             <key>workspace</key>
-             <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
-             <key>scheme</key>
-             <string>_SCHEME_NAME_HERE_</string>
-         </dict>
+        <dict>
+            <key>name</key>
+            <string>_FRAMEWORK_NAME_HERE_</string>
+            <key>targets</key>
+            <array>
+                <dict>
+                    <key>sdk</key>
+                    <string>_TARGET_OS_HERE_</string>
+                    <key>workspace</key>
+                    <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
+                    <key>scheme</key>
+                    <string>_SCHEME_NAME_HERE_</string>
+                </dict>
+            </array>
+        </dict>
      </array>
     <key>finalActions</key>
     <array>
@@ -39,13 +44,17 @@ import Foundation
  
  {
      "output_path": "_OUTPUT_DIRECTORY_NAME_HERE_",
-     "framework": "_FRAMEWORK_NAME_HERE_",
-     "targets": [
-     {
-         "sdk": "_TARGET_OS_HERE_",
-         "workspace": "_WORKSPACE_NAME_HERE_.xcworkspace",
-         "scheme": "_SCHEME_NAME_HERE_"
-     }],
+     "frameworks": [
+        {
+            "name": "_FRAMEWORK_NAME_HERE_",
+            "targets": [
+            {
+                "sdk": "_TARGET_OS_HERE_",
+                "workspace": "_WORKSPACE_NAME_HERE_.xcworkspace",
+                "scheme": "_SCHEME_NAME_HERE_"
+            }]
+        }
+     ],
      "finalActions": ["openDirectory"]
  }
 
@@ -55,22 +64,25 @@ import Foundation
  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
  <plist version="1.0">
      <dict>
-         <key>end_action</key>
-         <string>_OUTPUT_DIRECTORY_NAME_HERE_</string>
          <key>output_path</key>
          <string>_OUTPUT_DIRECTORY_NAME_HERE_</string>
-         <key>framework</key>
-         <string>_FRAMEWORK_NAME_HERE_</string>
-         <key>targets</key>
+         <key>frameworks</key>
          <array>
-             <dict>
-                 <key>sdk</key>
-                 <string>_TARGET_OS_HERE_</string>
-                 <key>workspace</key>
-                 <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
-                 <key>scheme</key>
-                 <string>_SCHEME_NAME_HERE_</string>
-             </dict>
+            <dict>
+                <key>name</key>
+                <string>_FRAMEWORK_NAME_HERE_</string>
+                <key>targets</key>
+                <array>
+                    <dict>
+                        <key>sdk</key>
+                        <string>_TARGET_OS_HERE_</string>
+                        <key>workspace</key>
+                        <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
+                        <key>scheme</key>
+                        <string>_SCHEME_NAME_HERE_</string>
+                    </dict>
+                </array>
+            </dict>
          </array>
         <key>finalActions</key>
         <array>

--- a/surmagic/Sources/surmagic/Target.swift
+++ b/surmagic/Sources/surmagic/Target.swift
@@ -41,7 +41,7 @@ public class Target: Codable {
             case .iOS:            return "generic/platform=iOS"
             case .iOSSimulator:   return "generic/platform=iOS Simulator"
             case .macOS:          return "generic/platform=macOS"
-            case .macOSCatalyst:  return "platform=macOS,variant=Mac Catalyst"
+            case .macOSCatalyst:  return "generic/platform=macOS,variant=Mac Catalyst"
             case .tvOS:           return "generic/platform=tvOS"
             case .tvOSSimulator:  return "generic/platform=tvOS Simulator"
             case .watchOS:        return "generic/platform=watchOS"

--- a/surmagic/Sources/surmagic/Target.swift
+++ b/surmagic/Sources/surmagic/Target.swift
@@ -35,6 +35,19 @@ public class Target: Codable {
             case .watchSimulator: return "watchsimulator"
             }
         }
+
+        var destination: String {
+            switch self {
+            case .iOS:            return "generic/platform=iOS"
+            case .iOSSimulator:   return "generic/platform=iOS Simulator"
+            case .macOS:          return "generic/platform=macOS"
+            case .macOSCatalyst:  return "platform=macOS,variant=Mac Catalyst"
+            case .tvOS:           return "generic/platform=tvOS"
+            case .tvOSSimulator:  return "generic/platform=tvOS Simulator"
+            case .watchOS:        return "generic/platform=watchOS"
+            case .watchSimulator: return "generic/platform=watchOS Simulator"
+            }
+        }
     }
     
     // MARK: - Types

--- a/surmagic/Sources/surmagic/XCFCommand.swift
+++ b/surmagic/Sources/surmagic/XCFCommand.swift
@@ -324,6 +324,7 @@ public class XCFCommand {
         arguments.append(archivePath)
 
         arguments.append("SKIP_INSTALL=NO")
+        arguments.append("BUILD_LIBRARY_FOR_DISTRIBUTION=YES")
 
         if target.sdk == .macOSCatalyst {
             arguments.append("SUPPORTS_MACCATALYST=YES")

--- a/surmagic/Sources/surmagic/XCFCommand.swift
+++ b/surmagic/Sources/surmagic/XCFCommand.swift
@@ -349,6 +349,9 @@ public class XCFCommand {
         arguments.append("-scheme")
         arguments.append(target.scheme)
         
+        arguments.append("-destination")
+        arguments.append(target.sdk.destination)
+        
         arguments.append("-archivePath")
         arguments.append(archivePath)
 

--- a/surmagic/Sources/surmagic/XCFCommand.swift
+++ b/surmagic/Sources/surmagic/XCFCommand.swift
@@ -34,28 +34,36 @@ public class XCFCommand {
             <dict>
                 <key>output_path</key>
                 <string>_OUTPUT_DIRECTORY_NAME_HERE_</string>
-                <key>framework</key>
-                <string>_FRAMEWORK_NAME_HERE_</string>
-                <key>targets</key>
+                <key>frameworks</key>
                 <array>
                     <dict>
-                        <key>sdk</key>
-                        <string>\(Target.SDK.iOS.rawValue)</string>
-                        <key>workspace</key>
-                        <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
-                        <key>scheme</key>
-                        <string>_SCHEME_NAME_HERE_</string>
-                    </dict>
-                    <dict>
-                        <key>sdk</key>
-                        <string>\(Target.SDK.iOSSimulator.rawValue)</string>
-                        <key>workspace</key>
-                        <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
-                        <key>scheme</key>
-                        <string>_SCHEME_NAME_HERE_</string>
+                        <key>name</key>
+                        <string>_FRAMEWORK_NAME_HERE_</string>
+                        <key>targets</key>
+                        <array>
+                            <dict>
+                                <key>sdk</key>
+                                <string>\(Target.SDK.iOS.rawValue)</string>
+                                <key>workspace</key>
+                                <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
+                                <key>scheme</key>
+                                <string>_SCHEME_NAME_HERE_</string>
+                            </dict>
+                            <dict>
+                                <key>sdk</key>
+                                <string>\(Target.SDK.iOSSimulator.rawValue)</string>
+                                <key>workspace</key>
+                                <string>_WORKSPACE_NAME_HERE_.xcworkspace</string>
+                                <key>scheme</key>
+                                <string>_SCHEME_NAME_HERE_</string>
+                            </dict>
+                            <!--
+                                Remove this comment and add more targets for Simulators and the Devices.
+                            -->
+                        </array>
                     </dict>
                     <!--
-                       Remove this comment and add more targets for Simulators and the Devices.
+                        Remove this comment and add more frameworks.
                     -->
                 </array>
                 <key>finalActions</key>

--- a/surmagic/Sources/surmagic/main.swift
+++ b/surmagic/Sources/surmagic/main.swift
@@ -21,7 +21,7 @@ struct Surmagic: ParsableCommand {
                   """,
 
         // Commands can define a version for automatic '--version' support.
-        version: "1.2.7",
+        version: "1.3.0",
         
         // Subcommands
         subcommands: [`init`.self, xcf.self, env.self],


### PR DESCRIPTION
File xcframework not generated due to no swiftinterface files generated (May be the reason for #15 ), fixed it by adding "BUILD_LIBRARY_FOR_DISTRIBUTION=YES" to xcodebuild arguments.

### ENV
```
 --------------------------- 

1.2.7

 --------------------------- 

Xcode 14.2
Build version 14C18

 --------------------------- 

ProductName:		macOS
ProductVersion:		13.1
BuildVersion:		22C65

 --------------------------- 
```

### Details
xcodebuild output error:
`No 'swiftinterface' files found within '/Users/xxx/Documents/Repos/iOS/SnapKit/SMoutput/iOS.xcarchive/Products/Library/Frameworks/SnapKit.framework/Modules/SnapKit.swiftmodule'.`
but surmagic still says:
`Successfully created a XCFramework on the location: ./xxxx`
in fact, the output folder only contains a Info.plist file.

Adding "BUILD_LIBRARY_FOR_DISTRIBUTION=YES" to xcodebuild arguments to make it generate swiftinterface files, this will solve the issue.